### PR TITLE
bump index version to fix broken indexes since upgrading deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ exports.version = '2.0.0'
 exports.manifest = { query: 'source' }
 
 exports.init = function (sbot) {
-  var search = sbot._flumeUse('search', FlumeViewSearch(12, 3, function (data) {
+  var search = sbot._flumeUse('search', FlumeViewSearch(13, 3, function (data) {
     return data.value.content.text
   }))
   return {


### PR DESCRIPTION
I have noticed that since upgrading to the latest versions of everything, that ssb-search is not returning the correct results. It only seems to be returning results since the point at which I upgraded.

For example: Search "hermies" "scuttlebot". Those should have hundreds of results, but for me (on hermies) there was 0 at first, and then today only 8. See https://github.com/ssbc/patchwork/issues/823

After deleting `~/.ssb/flume/search` and waiting for reindex, everything works correctly again.

I'm suspecting there must have been some kind of schema change, in some dep, somewhere.

Bumping the index version will fix this, but is there a better way?

cc @arj03 @dominictarr 