### PR TITLE
Freeze flumeview index version

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ function isString (s) {
   return 'string' === typeof s
 }
 
-const VERSION = 14
+const PERMANENT_VERSION = 14
+const INDEX_VERSION = 0
 const MIN_LENGTH = 3
 
 exports.init = function (sbot) {
-  var search = sbot._flumeUse('search', FlumeViewSearch(VERSION, MIN_LENGTH, function (data) {
+  var search = sbot._flumeUse('search' + (INDEX_VERSION || ''), FlumeViewSearch(PERMANENT_VERSION, MIN_LENGTH, function (data) {
     return data.value.content.text
   }))
   return {


### PR DESCRIPTION
This freezes the current index version, and introduces a new version variable which is used to determine the filename of the index on disk, starting with the current existing filename.

Context: [`%X80hCeiC+tiFKrqUnmdVkLz9eh8zR+H/4uZX0a74bR4=.sha256`](https://viewer.scuttlebot.io/%25X80hCeiC%2BtiFKrqUnmdVkLz9eh8zR%2BH%2F4uZX0a74bR4%3D.sha256)

> ### Proposal: freeze flumeview index versions
>
> Flumeviews (ssb-server indexes) have a version parameter which when changed triggers deletion and reconstruction of the index. This has been used when the index is updated to a new or changed index format.
>
> Index deletion in this way makes it difficult to switch between running different versions of an index, or between ssb apps using different versions of the index. This discourages users from trying different applications, switching between multiple applications or different versions of the same application, as there is a long reindexing period between launching the different applications using different versions of the same index. This could increase centralization of application usage by disincentivizing using multiple applications that vary in length of release cycles or otherwise prefer to use different versions of the same index. It also makes debugging more difficult, for the same reasons.
>
> Generally, different versions of the same index could coexist on disk, if only they would not overwrite eachother. Instead of deleting indexes, we could just use a new location on the filesystem for each new version of the index. This removes the conflict on the filename that indexes currently encounter.

> The main trade-off here is that multiple versions of the same index may accumulate in `~/.ssb`, taking up disk space. This is in keeping with existing trade-offs being made in ssb, namely that `~/.ssb` fills up with data but most of it can be safely deleted and is reconstructed if needed. An application could offer a command to delete old versions of its indexes, so that the user can decide if they want to do that - since the application on its own does not know what other applications or versions the user wants to be able to use.
>
> By removing the point of centralization of destructive index updates, I believe we can free up the ability for more applications to coexist and frustrate users less.